### PR TITLE
switch to namespace prefix and suffix

### DIFF
--- a/appOfApps/templates/application.yaml
+++ b/appOfApps/templates/application.yaml
@@ -2,13 +2,13 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: {{ .name }}-{{ .namespace | default $.Values.application.defaultNamespace }}
+  name: {{ .name }}-{{ $.Values.namespacePrefix }}{{ .namespaceSuffix }}
   labels:
     app.kubernetes.io/name: {{ .name }}
     app.kubernetes.io/instance-of: {{ $.Values.name }}
     app.kubernetes.io/managed-by: ArgoCD
     tenant: {{ $.Values.name }}
-  namespace: {{ default $.Values.gitops.namespace }}
+  namespace: {{ $.Values.namespacePrefix }}{{ $.Values.gitops.namespaceSuffix }}
   annotations:
     argocd.argoproj.io/sync-wave: "{{ .syncWave | default 0 }}"
 spec:
@@ -29,7 +29,7 @@ spec:
         {{- end }}
   destination:
     server: https://kubernetes.default.svc
-    namespace: {{ .namespace | default $.Values.application.defaultNamespace }}
+    namespace: {{ $.Values.namespacePrefix }}{{ .namespaceSuffix }}
   syncPolicy:
     automated: 
       prune: true

--- a/appOfApps/values.yaml
+++ b/appOfApps/values.yaml
@@ -21,19 +21,19 @@ defaultValuesFile: values.yaml
 applications:
   - name: vllm-model
     path: data-ingestion/vllm
-    namespaceSuffix: app
+    namespaceSuffix: apps
   - name: weaviate
     path: data-ingestion/weaviate
-    namespaceSuffix: app
+    namespaceSuffix: apps
   - name: kfp-pipeline
     path: data-ingestion/kfp
-    namespaceSuffix: app
+    namespaceSuffix: apps
   - name: quarkus-llm-router
     path: chatbot/quarkus-llm-router
-    namespaceSuffix: app
+    namespaceSuffix: apps
   - name: chatbot-ui
     path: chatbot/chatbot-ui
-    namespaceSuffix: app
+    namespaceSuffix: apps
     # Add ignoreDifferences to allow deployment to be updated by ImageStream
     ignoreDifferences:
       - group: apps
@@ -42,7 +42,7 @@ applications:
           - /spec/template/spec/containers/0/image
   - name: mongodb
     path: chatbot/mongodb
-    namespaceSuffix: app
+    namespaceSuffix: apps
   - name: bootstrap
     path: util/bootstrap
-    namespaceSuffix: app
+    namespaceSuffix: apps

--- a/appOfApps/values.yaml
+++ b/appOfApps/values.yaml
@@ -1,7 +1,6 @@
 name: composer-ai
-# Default Namespace for the application components
-application:
-  defaultNamespace: composer-ai-app 
+
+namespacePrefix: composer-ai-
 
 # Git Repository for the ArgoCD Application
 repo:
@@ -10,7 +9,7 @@ repo:
 
 # Namespace for the ArgoCD Application
 gitops:
-  namespace: openshift-gitops
+  namespaceSuffix: gitops
 
 # Passing this value to all of the sub-applications to make it so we can dynamically figure out urls
 clusterDomain: apps.cluster-c4gwj.c4gwj.sandbox1157.opentlc.com
@@ -22,14 +21,19 @@ defaultValuesFile: values.yaml
 applications:
   - name: vllm-model
     path: data-ingestion/vllm
+    namespaceSuffix: app
   - name: weaviate
     path: data-ingestion/weaviate
+    namespaceSuffix: app
   - name: kfp-pipeline
     path: data-ingestion/kfp
+    namespaceSuffix: app
   - name: quarkus-llm-router
     path: chatbot/quarkus-llm-router
+    namespaceSuffix: app
   - name: chatbot-ui
     path: chatbot/chatbot-ui
+    namespaceSuffix: app
     # Add ignoreDifferences to allow deployment to be updated by ImageStream
     ignoreDifferences:
       - group: apps
@@ -38,5 +42,7 @@ applications:
           - /spec/template/spec/containers/0/image
   - name: mongodb
     path: chatbot/mongodb
+    namespaceSuffix: app
   - name: bootstrap
     path: util/bootstrap
+    namespaceSuffix: app


### PR DESCRIPTION
Minor update to switch to using a central namespace prefix and a suffix for each app.

Goal, this is to allow us to more easily setup the multi-user environment with something like `composer-ai-user-1` as a prefix and things get assigned to `composer-ai-user-1-app` for the namespace.