### PR TITLE
Update Deployment and Values configuration for LLM Router to connect with Elasticsearch

### DIFF
--- a/conductor/quarkus-llm-router/templates/deployment.yaml
+++ b/conductor/quarkus-llm-router/templates/deployment.yaml
@@ -32,6 +32,11 @@ spec:
           resources:
             {{- .Values.resources | toYaml | nindent 12 }}
           env:
+            - name: ELASTICSEARCH_DEFAULT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: elasticsearch-es-elastic-user
+                  key: elastic
             - name: WEAVIATE_DEFAULT_APIKEY
               valueFrom:
                 secretKeyRef:

--- a/conductor/quarkus-llm-router/values.yaml
+++ b/conductor/quarkus-llm-router/values.yaml
@@ -7,7 +7,7 @@ labels:
 
 name: quarkus-llm-router
 
-image:  quay.io/redhat-saia/quarkus-routing-service:v2.1.1
+image: quay.io/redhat-saia/quarkus-routing-service:v2.2.0
 imagePullPolicy: Always
 
 serviceMesh:


### PR DESCRIPTION
This PR introduces essential updates to the quarkus-llm-router Helm chart/configurations required for the RHCAI setup to function properly with the Elasticsearch backend. These changes address an issue where the chatbot was still attempting to connect to Weaviate, despite it being disabled in a previous [PR](https://github.com/redhat-composer-ai/appOfApps/pull/15). Without these updates, the chatbot fails to operate as expected.

**Deployment configuration changes (deployment.yaml):**

- Added an environment variable for ELASTICSEARCH_DEFAULT_PASSWORD in the deployment template.

**Values configuration changes (values.yaml):**

- Updated the quarkus-routing-service image version from v2.1.1 to v2.2.0.