### PR TITLE
Application list to map

### DIFF
--- a/appOfApps/Chart.yaml
+++ b/appOfApps/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "v0.2.3"

--- a/appOfApps/templates/application.yaml
+++ b/appOfApps/templates/application.yaml
@@ -1,14 +1,14 @@
-{{- range .Values.applications }}
+{{- range $name, $val := .Values.applications }}
 # allow applications to be set to enabled: false
 # `.enabled | default true` always evaluates to true
 # reference: https://broersma.dev/til-helm-boolean-functions-and-falsy-ness/
-{{- if list nil true | has .enabled }}
+{{- if list nil true | has $val.enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: {{ .name }}-{{ $.Values.namespacePrefix }}{{ .namespaceSuffix }}
+  name: {{ $name }}-{{ $.Values.namespacePrefix }}{{ $val.namespaceSuffix }}
   labels:
-    app.kubernetes.io/name: {{ .name }}
+    app.kubernetes.io/name: {{ $name }}
     app.kubernetes.io/instance-of: {{ $.Values.name }}
     app.kubernetes.io/managed-by: ArgoCD
     tenant: {{ $.Values.name }}
@@ -19,28 +19,28 @@ spec:
   project: {{ $.Values.gitops.project | default "default" }}
   source:
     repoURL: {{ $.Values.repo.url }}
-    targetRevision: {{ .branch | default $.Values.repo.branch }}
-    path: {{ .path | default .name }}
+    targetRevision: {{ $val.branch | default $.Values.repo.branch }}
+    path: {{ $val.path | default $name }}
     helm:
       valueFiles: 
-        - {{ .valueFile | default $.Values.defaultValuesFile }}
+        - {{ $val.valueFile | default $.Values.defaultValuesFile }}
       parameters:
         - name: clusterDomain
           value: {{ $.Values.clusterDomain }}
-        {{- range .parameters }}
+        {{- range $val.parameters }}
         - name: {{ .name }}
           value: {{ .value }}
         {{- end }}
   destination:
     server: https://kubernetes.default.svc
-    namespace: {{ $.Values.namespacePrefix }}{{ .namespaceSuffix }}
+    namespace: {{ $.Values.namespacePrefix }}{{ $val.namespaceSuffix }}
   syncPolicy:
     automated: 
       prune: true
       selfHeal: true
-  {{- if .ignoreDifferences }}
+  {{- if $val.ignoreDifferences }}
   ignoreDifferences:
-    {{- toYaml .ignoreDifferences | nindent 4 }}
+    {{- toYaml $val.ignoreDifferences | nindent 4 }}
   {{- end }}
 ---
 {{- end }}

--- a/appOfApps/templates/application.yaml
+++ b/appOfApps/templates/application.yaml
@@ -1,12 +1,15 @@
-{{- range $name, $val := .Values.applications }}
-# allow applications to be set to enabled: false
-# `.enabled | default true` always evaluates to true
-# reference: https://broersma.dev/til-helm-boolean-functions-and-falsy-ness/
-{{- if list nil true | has $val.enabled }}
+{{- range $name, $val := .Values.applications -}}
+{{- with $val -}}
+{{- /*
+    allow applications to be set to enabled: false
+    `.enabled | default true` always evaluates to true
+    reference: https://broersma.dev/til-helm-boolean-functions-and-falsy-ness/
+*/ -}}
+{{- if list nil true | has .enabled }}
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: {{ $name }}-{{ $.Values.namespacePrefix }}{{ $val.namespaceSuffix }}
+  name: {{ $name }}-{{ $.Values.namespacePrefix }}{{ .namespaceSuffix }}
   labels:
     app.kubernetes.io/name: {{ $name }}
     app.kubernetes.io/instance-of: {{ $.Values.name }}
@@ -19,29 +22,30 @@ spec:
   project: {{ $.Values.gitops.project | default "default" }}
   source:
     repoURL: {{ $.Values.repo.url }}
-    targetRevision: {{ $val.branch | default $.Values.repo.branch }}
-    path: {{ $val.path | default $name }}
+    targetRevision: {{ .branch | default $.Values.repo.branch }}
+    path: {{ .path | default $name }}
     helm:
       valueFiles: 
-        - {{ $val.valueFile | default $.Values.defaultValuesFile }}
+        - {{ .valueFile | default $.Values.defaultValuesFile }}
       parameters:
         - name: clusterDomain
           value: {{ $.Values.clusterDomain }}
-        {{- range $val.parameters }}
+        {{- range .parameters }}
         - name: {{ .name }}
           value: {{ .value }}
         {{- end }}
   destination:
     server: https://kubernetes.default.svc
-    namespace: {{ $.Values.namespacePrefix }}{{ $val.namespaceSuffix }}
+    namespace: {{ $.Values.namespacePrefix }}{{ .namespaceSuffix }}
   syncPolicy:
     automated: 
       prune: true
       selfHeal: true
-  {{- if $val.ignoreDifferences }}
+  {{- if .ignoreDifferences }}
   ignoreDifferences:
-    {{- toYaml $val.ignoreDifferences | nindent 4 }}
+    {{- toYaml .ignoreDifferences | nindent 4 }}
   {{- end }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}

--- a/appOfApps/values.yaml
+++ b/appOfApps/values.yaml
@@ -13,23 +13,23 @@ clusterDomain: apps.cluster-c4gwj.c4gwj.sandbox1157.opentlc.com
 defaultValuesFile: values.yaml
 # Applications to be deployed
 applications:
-  - name: vllm-model
+  vllm-model:
     path: vllm
     namespaceSuffix: apps
-  - name: weaviate
+  weaviate:
     path: weaviate
     namespaceSuffix: apps
     enabled: false
-  - name: elasticsearch
+  elasticsearch:
     path: elasticsearch
     namespaceSuffix: apps
-  - name: kfp-pipeline
+  kfp-pipeline:
     path: kfp
     namespaceSuffix: apps
-  - name: quarkus-llm-router
+  quarkus-llm-router:
     path: conductor/quarkus-llm-router
     namespaceSuffix: apps
-  - name: chatbot-ui
+  chatbot-ui:
     path: chatbot-ui
     namespaceSuffix: apps
     # Add ignoreDifferences to allow deployment to be updated by ImageStream
@@ -38,9 +38,9 @@ applications:
         kind: Deployment
         jsonPointers:
           - /spec/template/spec/containers/0/image
-  - name: mongodb
+  mongodb:
     path: conductor/mongodb
     namespaceSuffix: apps
-  - name: bootstrap
+  bootstrap:
     path: util/bootstrap
     namespaceSuffix: apps


### PR DESCRIPTION
this allows for directly setting application parameters in argo/helm when installing the chart from the main repo

i.e. helm template composer-demo ./ --set "applications.elasticsearch.enabled=false,applications.mongodb.parameters[0].name=networkPolicy.enabled,applications.mongodb.parameters[0].value=true"